### PR TITLE
Add -norc to avoid conflicting system/user configuration of latexmk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ for d in de/beispiele en/examples; do
 			sed -i "s/pantone312]/$options]/" "$filename.tex"
 			# run compilations
 			latexmk "-$latex_engine" -interaction=nonstopmode -silent \
-				"$filename.tex"
+				-norc "$filename.tex"
 		done
 	done
 	# remove source files


### PR DESCRIPTION
Alternatively, one could explicitly set `-pv-` and `-pvc-` to prevent the loop from showing intermediate results.